### PR TITLE
Fix iOS Link Error

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FLTEnableImpeller</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/ffigen_ailia_tokenizer.yaml
+++ b/ffigen_ailia_tokenizer.yaml
@@ -1,0 +1,8 @@
+﻿name: 'ailiaTokenizerFFI'
+description: 'Written for the FFI article'
+output: 'lib/ffi/ailia_tokenizer.dart'
+headers:
+  entry-points:
+    - 'native/ailia_tokenizer.h'
+llvm-path:
+  - '/usr/local/opt/llvm@15'

--- a/ios/Classes/AiliaTokenizerPluginPreventStrip.c
+++ b/ios/Classes/AiliaTokenizerPluginPreventStrip.c
@@ -1,0 +1,13 @@
+//
+//  AiliaTokenizerPluginPreventStrip.c
+//
+//  Created by Kazuki Kyakuno on 2023/07/31.
+//
+
+// Dummy link to keep libailia_tokenizer.a from being deleted
+
+extern int ailiaTokenizerCreate(void** net, int type, int flags);
+
+void test(void){
+    ailiaTokenizerCreate(0, 0, 0);
+}

--- a/ios/ailia_tokenizer.podspec
+++ b/ios/ailia_tokenizer.podspec
@@ -15,6 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.vendored_libraries = '*.a'
+  s.libraries = "ailia_tokenizer"
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
iOSでシンボルがStripされてリンクエラーもしくはシンボルが見つからないエラーになる問題を修正。

- AiliaTokenizerPluginPreventStrip.cで明示的に.aの中の関数を呼び出してStripを抑制
- podspecにlibraries属性を追加
- exampleのFlutterでFLTEnableImpellerのエラーになる問題を修正